### PR TITLE
Add dataschema and datacontenttype

### DIFF
--- a/cloudevents.go
+++ b/cloudevents.go
@@ -14,13 +14,20 @@ type CloudEvent[A any] struct {
 	// this is always "1.0".
 	SpecVersion string `json:"specversion"`
 	// Subject is an optional field identifying the subject of the event within
-	// the context of the event producer.
+	// the context of the event producer. In practice, we always set this.
 	Subject string `json:"subject"`
-	// Time is an optional field giving the time at which the event occurred.
+	// Time is an optional field giving the time at which the event occurred. In
+	// practice, we always set this.
 	Time time.Time `json:"time"`
 	// Type describes the type of event. It should generally be a reverse-DNS
 	// name.
 	Type string `json:"type"`
+	// DataContentType is an optional MIME type for the data field. We almost
+	// always serialize to JSON and in that case this field is implicitly
+	// "application/json".
+	DataContentType string `json:"datacontenttype,omitempty"`
+	// DataSchema is an optional URI pointing to a schema for the data field.
+	DataSchema string `json:"dataschema,omitempty"`
 	// Data contains domain-specific information about the event.
 	Data A `json:"data"`
 }


### PR DESCRIPTION
Add [dataschema](https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md#dataschema) and [datacontenttype](https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md#datacontenttype) fields to CloudEvents.