### PR TITLE
Adds inline support for loading config from ENV.

### DIFF
--- a/config_loader.go
+++ b/config_loader.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"reflect"
 	"strconv"
+	"strings"
 
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v3"
@@ -51,15 +52,18 @@ func loadFromEnvVars[S any](settings S) error {
 	for i := 0; i < valueOfConfig.NumField(); i++ {
 		field := valueOfConfig.Field(i)
 		fieldYamlName := typeOfT.Field(i).Tag.Get("yaml")
-
+		if fieldYamlName == "-" {
+			continue
+		}
 		if field.Kind() == reflect.Struct {
 			// iterate through the fields - like above, prepend fieldYamlName
 			for i := 0; i < field.NumField(); i++ {
 				subField := field.Field(i)
 				subFieldYamlName := field.Type().Field(i).Tag.Get("yaml")
-				if fieldYamlName != ",inline" {
+				if !strings.HasSuffix(fieldYamlName, ",inline") {
 					subFieldYamlName = fieldYamlName + "_" + subFieldYamlName
 				}
+
 				err = matchEnvVarToField(subFieldYamlName, subField)
 			}
 		} else {

--- a/config_loader.go
+++ b/config_loader.go
@@ -56,7 +56,10 @@ func loadFromEnvVars[S any](settings S) error {
 			// iterate through the fields - like above, prepend fieldYamlName
 			for i := 0; i < field.NumField(); i++ {
 				subField := field.Field(i)
-				subFieldYamlName := fieldYamlName + "_" + field.Type().Field(i).Tag.Get("yaml")
+				subFieldYamlName := field.Type().Field(i).Tag.Get("yaml")
+				if fieldYamlName != ",inline" {
+					subFieldYamlName = fieldYamlName + "_" + subFieldYamlName
+				}
 				err = matchEnvVarToField(subFieldYamlName, subField)
 			}
 		} else {

--- a/config_loader_test.go
+++ b/config_loader_test.go
@@ -14,6 +14,7 @@ DB_CONNECT_STRING: mydb.aws.net
 ENV: dev
 REDIS:
   URL: redis.bobby
+INLINE_URL: inline.bobby
 `
 	settings, err := loadFromYaml[TestSettings]([]byte(data))
 	assert.NoError(t, err, "no error expected")
@@ -22,6 +23,7 @@ REDIS:
 	assert.Equal(t, "mydb.aws.net", settings.DbConnectString)
 	assert.Equal(t, "dev", settings.Env)
 	assert.Equal(t, "redis.bobby", settings.Redis.URL)
+	assert.Equal(t, "inline.bobby", settings.Inline.URL)
 }
 
 func Test_loadFromEnvVars(t *testing.T) {
@@ -34,6 +36,7 @@ func Test_loadFromEnvVars(t *testing.T) {
 	t.Setenv("ENV", "test")
 	t.Setenv("PORT", "5000")
 	t.Setenv("REDIS_URL", "redis.bobby")
+	t.Setenv("INLINE_URL", "inline.bobby")
 
 	err := loadFromEnvVars(&settings) // b/c of type inference we don't need to specify the type
 	assert.NoError(t, err)
@@ -42,6 +45,7 @@ func Test_loadFromEnvVars(t *testing.T) {
 	assert.Equal(t, 5000, settings.Port)
 	assert.Equal(t, "mydb.aws.net", settings.DbConnectString)
 	assert.Equal(t, "redis.bobby", settings.Redis.URL)
+	assert.Equal(t, "inline.bobby", settings.Inline.URL)
 }
 
 func Test_loadFromEnvVars_errIfNotPointer(t *testing.T) {
@@ -65,12 +69,17 @@ func Test_matchEnvVarToField(t *testing.T) {
 }
 
 type TestSettings struct {
-	Port            int          `yaml:"PORT"`
-	DbConnectString string       `yaml:"DB_CONNECT_STRING"`
-	Env             string       `yaml:"ENV"`
-	Redis           RedisSubProp `yaml:"REDIS"`
+	Port            int           `yaml:"PORT"`
+	DbConnectString string        `yaml:"DB_CONNECT_STRING"`
+	Env             string        `yaml:"ENV"`
+	Redis           RedisSubProp  `yaml:"REDIS"`
+	Inline          InlineSubProp `yaml:",inline"`
 }
 
 type RedisSubProp struct {
 	URL string `yaml:"URL"`
+}
+
+type InlineSubProp struct {
+	URL string `yaml:"INLINE_URL"`
 }

--- a/config_loader_test.go
+++ b/config_loader_test.go
@@ -15,6 +15,7 @@ ENV: dev
 REDIS:
   URL: redis.bobby
 INLINE_URL: inline.bobby
+IGNORE: ignoreme
 `
 	settings, err := loadFromYaml[TestSettings]([]byte(data))
 	assert.NoError(t, err, "no error expected")
@@ -24,6 +25,7 @@ INLINE_URL: inline.bobby
 	assert.Equal(t, "dev", settings.Env)
 	assert.Equal(t, "redis.bobby", settings.Redis.URL)
 	assert.Equal(t, "inline.bobby", settings.Inline.URL)
+	assert.Equal(t, "", settings.Ignore)
 }
 
 func Test_loadFromEnvVars(t *testing.T) {
@@ -37,6 +39,7 @@ func Test_loadFromEnvVars(t *testing.T) {
 	t.Setenv("PORT", "5000")
 	t.Setenv("REDIS_URL", "redis.bobby")
 	t.Setenv("INLINE_URL", "inline.bobby")
+	t.Setenv("IGNORE", "ignoreme")
 
 	err := loadFromEnvVars(&settings) // b/c of type inference we don't need to specify the type
 	assert.NoError(t, err)
@@ -46,6 +49,7 @@ func Test_loadFromEnvVars(t *testing.T) {
 	assert.Equal(t, "mydb.aws.net", settings.DbConnectString)
 	assert.Equal(t, "redis.bobby", settings.Redis.URL)
 	assert.Equal(t, "inline.bobby", settings.Inline.URL)
+	assert.Equal(t, "", settings.Ignore)
 }
 
 func Test_loadFromEnvVars_errIfNotPointer(t *testing.T) {
@@ -74,6 +78,7 @@ type TestSettings struct {
 	Env             string        `yaml:"ENV"`
 	Redis           RedisSubProp  `yaml:"REDIS"`
 	Inline          InlineSubProp `yaml:",inline"`
+	Ignore          string        `yaml:"-"`
 }
 
 type RedisSubProp struct {

--- a/config_loader_test.go
+++ b/config_loader_test.go
@@ -25,7 +25,7 @@ IGNORE: ignoreme
 	assert.Equal(t, "dev", settings.Env)
 	assert.Equal(t, "redis.bobby", settings.Redis.URL)
 	assert.Equal(t, "inline.bobby", settings.Inline.URL)
-	assert.Equal(t, "", settings.Ignore)
+	assert.Equal(t, "", settings.IGNORE)
 }
 
 func Test_loadFromEnvVars(t *testing.T) {
@@ -49,7 +49,7 @@ func Test_loadFromEnvVars(t *testing.T) {
 	assert.Equal(t, "mydb.aws.net", settings.DbConnectString)
 	assert.Equal(t, "redis.bobby", settings.Redis.URL)
 	assert.Equal(t, "inline.bobby", settings.Inline.URL)
-	assert.Equal(t, "", settings.Ignore)
+	assert.Equal(t, "", settings.IGNORE)
 }
 
 func Test_loadFromEnvVars_errIfNotPointer(t *testing.T) {
@@ -78,7 +78,7 @@ type TestSettings struct {
 	Env             string        `yaml:"ENV"`
 	Redis           RedisSubProp  `yaml:"REDIS"`
 	Inline          InlineSubProp `yaml:",inline"`
-	Ignore          string        `yaml:"-"`
+	IGNORE          string        `yaml:"-"`
 }
 
 type RedisSubProp struct {


### PR DESCRIPTION
# Proposed Changes
Update the Config from  ENV code to support `,inline` and `-` to match the yaml decoding behavior
https://pkg.go.dev/gopkg.in/yaml.v3#Marshal