### PR TITLE
Support `url.URL` for url types

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,14 @@ Convention over configuration library for typed configurations that can read fro
 way of dealing with configurations: for local development we want to use yaml config files, and on higher level environments 
 we want settings to come from environment variables (we use kubernetes). Supported types are: string, int, int64, bool. 
 
+### adding custom types
+
+1. modify the config_loader_test.go by updating the tests (`Test_loadFromEnvVars` and `Test_loadFromYaml`) for your scenario with the desired type in the example settings struct
+2. modify config_loader func `matchEnvVarToField` by adding a case for your type.
+3. modify `loadFromEnvVars` by adding to the specialTypes list.
+4. modify the `yaml` library per readme there, git push, make a release
+5. then go get with the new version eg. `go get github.com/DIMO-Network/yaml@v0.1.0` from this repo
+
 ## gRPC library
 
 We should probably put these in the repositories of the services that own them, but we are putting this off for now. To make changes to the current suite for, e.g., the devices API, run

--- a/config_loader.go
+++ b/config_loader.go
@@ -2,6 +2,7 @@ package shared
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"reflect"
 	"strconv"
@@ -82,6 +83,12 @@ func matchEnvVarToField(envVarName string, field reflect.Value) error { // other
 		var val any
 		switch field.Kind() {
 		case reflect.String:
+			if strings.HasPrefix(env, "http") {
+				if urlParsed, err := url.Parse(env); err == nil {
+					val = urlParsed
+					break
+				}
+			}
 			val = env
 		case reflect.Bool:
 			val, err = strconv.ParseBool(env)

--- a/config_loader.go
+++ b/config_loader.go
@@ -2,6 +2,7 @@ package shared
 
 import (
 	"fmt"
+	"github.com/DIMO-Network/yaml"
 	"net/url"
 	"os"
 	"reflect"
@@ -9,7 +10,6 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
-	"gopkg.in/yaml.v3"
 )
 
 // LoadConfig fills in all the values in the Settings from local yml file (for dev) and env vars (for deployments)

--- a/config_loader_test.go
+++ b/config_loader_test.go
@@ -1,6 +1,7 @@
 package shared
 
 import (
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 	"net/url"
 	"reflect"
@@ -15,7 +16,7 @@ PORT: 3000
 DB_CONNECT_STRING: mydb.aws.net
 ENV: dev
 REDIS:
-  URL: redis.bobby
+  URL: https://k8s-cluster-redis.dimo.zone:8776/redis
 INLINE_URL: inline.bobby
 IGNORE: ignoreme
 ACTUAL_URL_OBJECT: https://identity-api.dimo.zone/query
@@ -26,7 +27,7 @@ ACTUAL_URL_OBJECT: https://identity-api.dimo.zone/query
 	assert.Equal(t, 3000, settings.Port)
 	assert.Equal(t, "mydb.aws.net", settings.DbConnectString)
 	assert.Equal(t, "dev", settings.Env)
-	assert.Equal(t, "redis.bobby", settings.Redis.URL)
+	assert.Equal(t, "https://k8s-cluster-redis.dimo.zone:8776/redis", settings.Redis.URL.String())
 	assert.Equal(t, "inline.bobby", settings.Inline.URL)
 	assert.Equal(t, "", settings.IGNORE)
 	assert.Equal(t, "https://identity-api.dimo.zone/query", settings.ActualURLObject.String())
@@ -43,10 +44,11 @@ func Test_loadFromEnvVars(t *testing.T) {
 	// these will now override the above
 	t.Setenv("ENV", "test")
 	t.Setenv("PORT", "5000")
-	t.Setenv("REDIS_URL", "redis.bobby")
+	t.Setenv("REDIS_URL", "https://k8s-cluster-redis.dimo.zone:8776/redis")
 	t.Setenv("INLINE_URL", "inline.bobby")
 	t.Setenv("IGNORE", "ignoreme")
 	t.Setenv("ACTUAL_URL_OBJECT", "https://identity-api.dimo.zone/query")
+	t.Setenv("MINT_VEHICLE_NFT_CONTRACT", "0x45fbCD3ef7361d156e8b16F5538AE36DEdf61Da8")
 
 	err := loadFromEnvVars(&settings) // b/c of type inference we don't need to specify the type
 	require.NoError(t, err)
@@ -54,12 +56,13 @@ func Test_loadFromEnvVars(t *testing.T) {
 	assert.Equal(t, "test", settings.Env)
 	assert.Equal(t, 5000, settings.Port)
 	assert.Equal(t, "mydb.aws.net", settings.DbConnectString)
-	assert.Equal(t, "redis.bobby", settings.Redis.URL)
+	assert.Equal(t, "https://k8s-cluster-redis.dimo.zone:8776/redis", settings.Redis.URL.String())
 	assert.Equal(t, "inline.bobby", settings.Inline.URL)
 	assert.Equal(t, "", settings.IGNORE)
 	assert.Equal(t, "https://identity-api.dimo.zone/query", settings.ActualURLObject.String())
 	assert.Equal(t, "/query", settings.ActualURLObject.Path)
 	assert.Equal(t, "identity-api.dimo.zone", settings.ActualURLObject.Host)
+	assert.Equal(t, "0x45fbCD3ef7361d156e8b16F5538AE36DEdf61Da8", settings.MintVehicleNFTContract.String())
 }
 
 func Test_loadFromEnvVars_errIfNotPointer(t *testing.T) {
@@ -100,17 +103,18 @@ func Test_matchEnvVarToField_Url(t *testing.T) {
 }
 
 type TestSettings struct {
-	Port            int           `yaml:"PORT"`
-	DbConnectString string        `yaml:"DB_CONNECT_STRING"`
-	Env             string        `yaml:"ENV"`
-	Redis           RedisSubProp  `yaml:"REDIS"`
-	Inline          InlineSubProp `yaml:",inline"`
-	IGNORE          string        `yaml:"-"`
-	ActualURLObject url.URL       `yaml:"ACTUAL_URL_OBJECT"`
+	Port                   int            `yaml:"PORT"`
+	DbConnectString        string         `yaml:"DB_CONNECT_STRING"`
+	Env                    string         `yaml:"ENV"`
+	Redis                  RedisSubProp   `yaml:"REDIS"`
+	Inline                 InlineSubProp  `yaml:",inline"`
+	IGNORE                 string         `yaml:"-"`
+	ActualURLObject        url.URL        `yaml:"ACTUAL_URL_OBJECT"`
+	MintVehicleNFTContract common.Address `yaml:"MINT_VEHICLE_NFT_CONTRACT"`
 }
 
 type RedisSubProp struct {
-	URL string `yaml:"URL"`
+	URL url.URL `yaml:"URL"`
 }
 
 type InlineSubProp struct {

--- a/config_loader_test.go
+++ b/config_loader_test.go
@@ -21,8 +21,8 @@ IGNORE: ignoreme
 ACTUAL_URL_OBJECT: https://identity-api.dimo.zone/query
 `
 	settings, err := loadFromYaml[TestSettings]([]byte(data))
-	assert.NoError(t, err, "no error expected")
-	assert.NotNilf(t, settings, "settings not expected to be nil")
+	require.NoError(t, err, "no error expected")
+	require.NotNilf(t, settings, "settings not expected to be nil")
 	assert.Equal(t, 3000, settings.Port)
 	assert.Equal(t, "mydb.aws.net", settings.DbConnectString)
 	assert.Equal(t, "dev", settings.Env)

--- a/config_loader_test.go
+++ b/config_loader_test.go
@@ -20,6 +20,7 @@ REDIS:
 INLINE_URL: inline.bobby
 IGNORE: ignoreme
 ACTUAL_URL_OBJECT: https://identity-api.dimo.zone/query
+MINT_VEHICLE_NFT_CONTRACT: 0x45fbCD3ef7361d156e8b16F5538AE36DEdf61Da8
 `
 	settings, err := loadFromYaml[TestSettings]([]byte(data))
 	require.NoError(t, err, "no error expected")
@@ -33,6 +34,7 @@ ACTUAL_URL_OBJECT: https://identity-api.dimo.zone/query
 	assert.Equal(t, "https://identity-api.dimo.zone/query", settings.ActualURLObject.String())
 	assert.Equal(t, "/query", settings.ActualURLObject.Path)
 	assert.Equal(t, "identity-api.dimo.zone", settings.ActualURLObject.Host)
+	assert.Equal(t, "0x45fbCD3ef7361d156e8b16F5538AE36DEdf61Da8", settings.MintVehicleNFTContract.String())
 }
 
 func Test_loadFromEnvVars(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/DIMO-Network/shared
 
-go 1.21
+go 1.22.3
+
+toolchain go1.22.6
 
 require (
 	github.com/IBM/sarama v1.43.3
@@ -22,8 +24,9 @@ require (
 	golang.org/x/exp v0.0.0-20240213143201-ec583247a57a
 	google.golang.org/grpc v1.61.1
 	google.golang.org/protobuf v1.33.0
-	gopkg.in/yaml.v3 v3.0.1
 )
+
+require github.com/DIMO-Network/yaml v0.0.0-20240829213909-b0be6e9dbcdc
 
 require (
 	github.com/beorn7/perks v1.0.1 // indirect
@@ -56,6 +59,7 @@ require (
 	github.com/volatiletech/strmangle v0.0.6 // indirect
 	golang.org/x/xerrors v0.0.0-20231012003039-104605ab7028 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240213162025-012b6fc9bca9 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	google.golang.org/protobuf v1.33.0
 )
 
-require github.com/DIMO-Network/yaml v0.0.0-20240829213909-b0be6e9dbcdc
+require github.com/DIMO-Network/yaml v0.1.0
 
 require (
 	github.com/beorn7/perks v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -65,6 +65,8 @@ github.com/DIMO-Network/yaml v0.0.0-20240829211632-fe064f6bb3ea h1:UBTHQ87nPvHeS
 github.com/DIMO-Network/yaml v0.0.0-20240829211632-fe064f6bb3ea/go.mod h1:ZnGYWIk212DH3rr71T92uMvQEkt3htOz7ZA5rhI1ijw=
 github.com/DIMO-Network/yaml v0.0.0-20240829213909-b0be6e9dbcdc h1:FEXR84MA7TdeLBtX3c+hTVJ9rpOHsAw4/hHWtYGzZV8=
 github.com/DIMO-Network/yaml v0.0.0-20240829213909-b0be6e9dbcdc/go.mod h1:ZnGYWIk212DH3rr71T92uMvQEkt3htOz7ZA5rhI1ijw=
+github.com/DIMO-Network/yaml v0.1.0 h1:KQ3oKHUZETchR6Pxbmmol3e4ewrPv/q8cEwqxfwyZbU=
+github.com/DIMO-Network/yaml v0.1.0/go.mod h1:KkiehcbkVzH8Pf8f9dja8B2aW81gYYZSqfwzSj9yN68=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/IBM/sarama v1.43.3 h1:Yj6L2IaNvb2mRBop39N7mmJAHBVY3dTPncr3qGVkxPA=
 github.com/IBM/sarama v1.43.3/go.mod h1:FVIRaLrhK3Cla/9FfRF5X9Zua2KpS3SYIXxhac1H+FQ=

--- a/go.sum
+++ b/go.sum
@@ -61,6 +61,10 @@ github.com/AzureAD/microsoft-authentication-library-for-go v0.4.0/go.mod h1:Vt9s
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/DATA-DOG/go-sqlmock v1.4.1/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
+github.com/DIMO-Network/yaml v0.0.0-20240829211632-fe064f6bb3ea h1:UBTHQ87nPvHeS3CdEvncHYSPGNPe05J+ogpt+jOAbOw=
+github.com/DIMO-Network/yaml v0.0.0-20240829211632-fe064f6bb3ea/go.mod h1:ZnGYWIk212DH3rr71T92uMvQEkt3htOz7ZA5rhI1ijw=
+github.com/DIMO-Network/yaml v0.0.0-20240829213909-b0be6e9dbcdc h1:FEXR84MA7TdeLBtX3c+hTVJ9rpOHsAw4/hHWtYGzZV8=
+github.com/DIMO-Network/yaml v0.0.0-20240829213909-b0be6e9dbcdc/go.mod h1:ZnGYWIk212DH3rr71T92uMvQEkt3htOz7ZA5rhI1ijw=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/IBM/sarama v1.43.3 h1:Yj6L2IaNvb2mRBop39N7mmJAHBVY3dTPncr3qGVkxPA=
 github.com/IBM/sarama v1.43.3/go.mod h1:FVIRaLrhK3Cla/9FfRF5X9Zua2KpS3SYIXxhac1H+FQ=


### PR DESCRIPTION
# Proposed Changes

@elffjs brought up good point of wanting more type support for commonly used types, eg. url.URL, which we use often and then parsing the string is silly in every project if this could do it. Or error if invalid url format. 
I could also see this for EOA's eg. some `0x` contract address, etc. 

### Impacted Packages
<!-- Will this pull request change or implement any packages -->

### Caveats
<!-- If there is anything hacky or unique being added in your code please define it.-->

Current challenge is with our yaml supporting these types, b/c we abstract that all to an external library. I mean it seems silly they wouldn't support other types but might spend some time to see if that is a possibility with github.com/go-yaml/yaml

Fixed this by forking yaml lib and making a change to it. Could improve that for pattern to support more types. 