### PR TITLE
fix(http): stop labeling all GraphQL errors as "identity api"

### DIFF
--- a/pkg/http/http_client_wrapper.go
+++ b/pkg/http/http_client_wrapper.go
@@ -151,7 +151,7 @@ func (h clientWrapper) GraphQLQueryRaw(authHeader, query string) ([]byte, error)
 	if err != nil {
 		// not sure why we do this
 		if _, ok := err.(ResponseError); !ok {
-			return nil, errors.Wrapf(err, "error calling identity api from url %s. request: %s", h.baseURL, string(payloadBytes))
+			return nil, errors.Wrapf(err, "failed to call url %s. graphql request: %s", h.baseURL, string(payloadBytes))
 		}
 	}
 	defer res.Body.Close() // nolint


### PR DESCRIPTION
## Problem
`clientWrapper.GraphQLQueryRaw` wraps every failed GraphQL call with a hardcoded **"identity api"** label, regardless of which service the client targets:

```go
errors.Wrapf(err, "error calling identity api from url %s. request: %s", h.baseURL, …)
```

Since this wrapper backs *all* GraphQL clients (identity-api, fetch-api, telemetry-api, …), failures against any of them are logged as identity-api errors. In practice this produced misleading logs like:

```
error calling identity api from url https://fetch-api.dimo.zone/query …
```

while triaging a fetch-api 422 — the URL is fetch-api but the message says identity api.

## Fix
Use a generic, accurate message:

```go
errors.Wrapf(err, "failed to call url %s. graphql request: %s", h.baseURL, …)
```

`GraphQLQuery` (typed) delegates to `GraphQLQueryRaw`, so this single change covers both entry points and every caller.

## Verification
- `go build ./...` clean.
- `go test ./pkg/http/...` passes.

> ⚠️ Note: `Test_clientWrapper_GraphQLQueryRaw_retriesAndSucceeds` is **flaky** on both this branch and `main` (it asserts exactly 3 retry attempts but intermittently observes 4 — a timing race in the retry, unrelated to this string change). If CI red-flags it, a re-run clears it. Happy to fix the flake in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)