### PR TITLE
ci: pin golangci-lint to v2.11.3 (latest govet regression)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,6 +22,10 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v7
         with:
-          version: latest
+          # Pinned: `latest` (v2.12.x) regressed — its bundled govet `inline`
+          # analyzer hard-errors on generic stdlib calls ("cannot inline: type
+          # parameter inference is not yet supported"), failing lint on every PR.
+          # v2.11.3 is verified clean against this module.
+          version: v2.11.3
           only-new-issues: false
           args: --modules-download-mode=readonly --timeout=5m


### PR DESCRIPTION
## Problem
The lint job pins `golangci/golangci-lint-action@v7` but `version: latest`, which now resolves to **v2.12.x**. Its bundled `govet` `inline` analyzer hard-errors on generic stdlib calls:

```
pkg/middleware/privilegetoken/main.go:77:24: inline: cannot inline: type parameter inference is not yet supported (govet)
```

That's a tooling regression (the line is a plain `slices.Contains` call), and it fails lint on **every** open PR regardless of its contents.

## Fix
Pin the linter to **v2.11.3**, verified clean (`0 issues`) across the whole module locally. Keeps lint deterministic instead of tracking `latest`.

## Verification
```
$ golangci-lint run --timeout=5m ./...
0 issues.   # v2.11.3
```

## Follow-up
This unblocks the other open shared PR (#114, the fetch-api error-message fix), which is red only because of this same `latest` regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)